### PR TITLE
Remove saving xlsx

### DIFF
--- a/docs/source/api/ppkt2synergy.core.rst
+++ b/docs/source/api/ppkt2synergy.core.rst
@@ -18,7 +18,7 @@ ppkt2synergy.core.features module
    :show-inheritance:
 
 ppkt2synergy.core.predicates module
----------------------------------
+-----------------------------------
 
 .. automodule:: ppkt2synergy.core.predicates
    :members:
@@ -26,7 +26,7 @@ ppkt2synergy.core.predicates module
    :show-inheritance:
 
 ppkt2synergy.core.builder module
-======================================
+-----------------------------------
 
 .. automodule:: ppkt2synergy.core.builder
    :members:

--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -73,7 +73,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Individuals Processed: 100%|██████████| 143/143 [00:00<00:00, 458.84 individuals/s]\n"
+      "Individuals Processed: 100%|██████████| 143/143 [00:00<00:00, 435.86 individuals/s]\n"
      ]
     }
    ],
@@ -108,7 +108,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Calculating pairwise correlation: 100%|██████████| 728/728 [00:01<00:00, 474.87it/s] \n"
+      "Calculating pairwise correlation: 100%|██████████| 728/728 [00:01<00:00, 394.09it/s]\n"
      ]
     },
     {
@@ -666,6 +666,12 @@
        "      <td>8 (88.9%)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
+       "      <th>SPLICE_REGION_VARIANT</th>\n",
+       "      <td>6 (4.0%)</td>\n",
+       "      <td>6 (4.0%)</td>\n",
+       "      <td>1 (11.1%)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>STOP_GAINED</th>\n",
        "      <td>4 (2.6%)</td>\n",
        "      <td>4 (2.6%)</td>\n",
@@ -675,6 +681,18 @@
        "      <th>SPLICE_DONOR_VARIANT</th>\n",
        "      <td>6 (4.0%)</td>\n",
        "      <td>6 (4.0%)</td>\n",
+       "      <td>0 (0.0%)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>INFRAME_DELETION</th>\n",
+       "      <td>1 (0.7%)</td>\n",
+       "      <td>1 (0.7%)</td>\n",
+       "      <td>0 (0.0%)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>INFRAME_INSERTION</th>\n",
+       "      <td>1 (0.7%)</td>\n",
+       "      <td>1 (0.7%)</td>\n",
        "      <td>0 (0.0%)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -696,25 +714,13 @@
        "      <td>0 (0.0%)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>SPLICE_REGION_VARIANT</th>\n",
-       "      <td>6 (4.0%)</td>\n",
-       "      <td>6 (4.0%)</td>\n",
-       "      <td>1 (11.1%)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>INFRAME_INSERTION</th>\n",
-       "      <td>1 (0.7%)</td>\n",
-       "      <td>1 (0.7%)</td>\n",
-       "      <td>0 (0.0%)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>INFRAME_DELETION</th>\n",
-       "      <td>1 (0.7%)</td>\n",
-       "      <td>1 (0.7%)</td>\n",
-       "      <td>0 (0.0%)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>SYNONYMOUS_VARIANT</th>\n",
+       "      <td>1 (0.7%)</td>\n",
+       "      <td>1 (0.7%)</td>\n",
+       "      <td>0 (0.0%)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SPLICE_DONOR_REGION_VARIANT</th>\n",
        "      <td>1 (0.7%)</td>\n",
        "      <td>1 (0.7%)</td>\n",
        "      <td>0 (0.0%)</td>\n",
@@ -725,12 +731,6 @@
        "      <td>2 (1.3%)</td>\n",
        "      <td>0 (0.0%)</td>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>SPLICE_DONOR_REGION_VARIANT</th>\n",
-       "      <td>1 (0.7%)</td>\n",
-       "      <td>1 (0.7%)</td>\n",
-       "      <td>0 (0.0%)</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
@@ -739,17 +739,17 @@
        "transcript_id                  NM_000138.5 NM_001406716.1 NM_001406717.1\n",
        "variant_effect                                                          \n",
        "MISSENSE_VARIANT               119 (78.8%)    119 (78.8%)      8 (88.9%)\n",
+       "SPLICE_REGION_VARIANT             6 (4.0%)       6 (4.0%)      1 (11.1%)\n",
        "STOP_GAINED                       4 (2.6%)       4 (2.6%)       0 (0.0%)\n",
        "SPLICE_DONOR_VARIANT              6 (4.0%)       6 (4.0%)       0 (0.0%)\n",
+       "INFRAME_DELETION                  1 (0.7%)       1 (0.7%)       0 (0.0%)\n",
+       "INFRAME_INSERTION                 1 (0.7%)       1 (0.7%)       0 (0.0%)\n",
        "FRAMESHIFT_VARIANT                7 (4.6%)       7 (4.6%)       0 (0.0%)\n",
        "SPLICE_DONOR_5TH_BASE_VARIANT     1 (0.7%)       1 (0.7%)       0 (0.0%)\n",
        "INTRON_VARIANT                    2 (1.3%)       2 (1.3%)       0 (0.0%)\n",
-       "SPLICE_REGION_VARIANT             6 (4.0%)       6 (4.0%)      1 (11.1%)\n",
-       "INFRAME_INSERTION                 1 (0.7%)       1 (0.7%)       0 (0.0%)\n",
-       "INFRAME_DELETION                  1 (0.7%)       1 (0.7%)       0 (0.0%)\n",
        "SYNONYMOUS_VARIANT                1 (0.7%)       1 (0.7%)       0 (0.0%)\n",
-       "SPLICE_ACCEPTOR_VARIANT           2 (1.3%)       2 (1.3%)       0 (0.0%)\n",
-       "SPLICE_DONOR_REGION_VARIANT       1 (0.7%)       1 (0.7%)       0 (0.0%)"
+       "SPLICE_DONOR_REGION_VARIANT       1 (0.7%)       1 (0.7%)       0 (0.0%)\n",
+       "SPLICE_ACCEPTOR_VARIANT           2 (1.3%)       2 (1.3%)       0 (0.0%)"
       ]
      },
      "execution_count": 10,
@@ -784,7 +784,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 11,
    "id": "4a4b346d",
    "metadata": {},
    "outputs": [],
@@ -804,7 +804,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 12,
    "id": "90be1d8c",
    "metadata": {},
    "outputs": [],
@@ -818,7 +818,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 13,
    "id": "61dba5b3",
    "metadata": {},
    "outputs": [
@@ -826,7 +826,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Calculating pairwise synergy: 100%|██████████| 606/606 [00:36<00:00, 16.62it/s]\n"
+      "Calculating pairwise synergy: 100%|██████████| 606/606 [00:36<00:00, 16.44it/s]\n"
      ]
     },
     {
@@ -874,27 +874,27 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>33</th>\n",
+       "      <th>39</th>\n",
        "      <td>HP:0000098</td>\n",
        "      <td>Tall stature</td>\n",
-       "      <td>HP:0001382</td>\n",
-       "      <td>Joint hypermobility</td>\n",
-       "      <td>0.097583</td>\n",
+       "      <td>HP:0002650</td>\n",
+       "      <td>Scoliosis</td>\n",
+       "      <td>0.137204</td>\n",
        "      <td>0.0001</td>\n",
        "      <td>0.008079</td>\n",
        "      <td>2</td>\n",
        "      <td>4</td>\n",
-       "      <td>6</td>\n",
+       "      <td>7</td>\n",
        "      <td>2</td>\n",
-       "      <td>14</td>\n",
-       "      <td>58</td>\n",
-       "      <td>2</td>\n",
+       "      <td>15</td>\n",
+       "      <td>36</td>\n",
+       "      <td>1</td>\n",
        "      <td>12</td>\n",
-       "      <td>17</td>\n",
-       "      <td>89</td>\n",
-       "      <td>103</td>\n",
-       "      <td>12</td>\n",
-       "      <td>10756346;11175294;12203992;20979188;21594992;2...</td>\n",
+       "      <td>16</td>\n",
+       "      <td>65</td>\n",
+       "      <td>80</td>\n",
+       "      <td>11</td>\n",
+       "      <td>10756346;11175294;12203992;20375004;22219643;2...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>277</th>\n",
@@ -920,27 +920,27 @@
        "      <td>10756346;11175294;12203992;20979188;21594992;2...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>39</th>\n",
+       "      <th>33</th>\n",
        "      <td>HP:0000098</td>\n",
        "      <td>Tall stature</td>\n",
-       "      <td>HP:0002650</td>\n",
-       "      <td>Scoliosis</td>\n",
-       "      <td>0.137204</td>\n",
+       "      <td>HP:0001382</td>\n",
+       "      <td>Joint hypermobility</td>\n",
+       "      <td>0.097583</td>\n",
        "      <td>0.0001</td>\n",
        "      <td>0.008079</td>\n",
        "      <td>2</td>\n",
        "      <td>4</td>\n",
-       "      <td>7</td>\n",
+       "      <td>6</td>\n",
        "      <td>2</td>\n",
-       "      <td>15</td>\n",
-       "      <td>36</td>\n",
-       "      <td>1</td>\n",
+       "      <td>14</td>\n",
+       "      <td>58</td>\n",
+       "      <td>2</td>\n",
        "      <td>12</td>\n",
-       "      <td>16</td>\n",
-       "      <td>65</td>\n",
-       "      <td>80</td>\n",
-       "      <td>11</td>\n",
-       "      <td>10756346;11175294;12203992;20375004;22219643;2...</td>\n",
+       "      <td>17</td>\n",
+       "      <td>89</td>\n",
+       "      <td>103</td>\n",
+       "      <td>12</td>\n",
+       "      <td>10756346;11175294;12203992;20979188;21594992;2...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>291</th>\n",
@@ -994,42 +994,42 @@
       ],
       "text/plain": [
        "          HPO_A                              HPO_A_label       HPO_B  \\\n",
-       "33   HP:0000098                             Tall stature  HP:0001382   \n",
-       "277  HP:0001187  Hyperextensibility of the finger joints  HP:0001519   \n",
        "39   HP:0000098                             Tall stature  HP:0002650   \n",
+       "277  HP:0001187  Hyperextensibility of the finger joints  HP:0001519   \n",
+       "33   HP:0000098                             Tall stature  HP:0001382   \n",
        "291  HP:0001382                      Joint hypermobility  HP:0001519   \n",
        "31   HP:0000098                             Tall stature  HP:0001187   \n",
        "\n",
        "                                 HPO_B_label   synergy  p_value  adj_p_value  \\\n",
-       "33                       Joint hypermobility  0.097583   0.0001     0.008079   \n",
-       "277            Disproportionate tall stature  0.028097   0.0001     0.008079   \n",
        "39                                 Scoliosis  0.137204   0.0001     0.008079   \n",
+       "277            Disproportionate tall stature  0.028097   0.0001     0.008079   \n",
+       "33                       Joint hypermobility  0.097583   0.0001     0.008079   \n",
        "291            Disproportionate tall stature  0.069756   0.0001     0.008079   \n",
        "31   Hyperextensibility of the finger joints  0.041162   0.0001     0.008079   \n",
        "\n",
        "     n(A:E/B:E)_y0  n(A:E/B:O)_y0  n(A:O/B:E)_y0  n(A:O/B:O)_y0  N_y0  \\\n",
-       "33               2              4              6              2    14   \n",
-       "277              4              5              3              0    12   \n",
        "39               2              4              7              2    15   \n",
+       "277              4              5              3              0    12   \n",
+       "33               2              4              6              2    14   \n",
        "291              4              5              5              1    15   \n",
        "31               2              3              6              0    11   \n",
        "\n",
        "     n(A:E/B:E)_y1  n(A:E/B:O)_y1  n(A:O/B:E)_y1  n(A:O/B:O)_y1  N_y1  \\\n",
-       "33              58              2             12             17    89   \n",
-       "277             67              4              0              0    71   \n",
        "39              36              1             12             16    65   \n",
+       "277             67              4              0              0    71   \n",
+       "33              58              2             12             17    89   \n",
        "291             67              4              9             10    90   \n",
        "31              58              0             12              0    70   \n",
        "\n",
        "     n_individuals  n_pmids                                              pmids  \n",
-       "33             103       12  10756346;11175294;12203992;20979188;21594992;2...  \n",
-       "277             83       11  10756346;11175294;12203992;20979188;21594992;2...  \n",
        "39              80       11  10756346;11175294;12203992;20375004;22219643;2...  \n",
+       "277             83       11  10756346;11175294;12203992;20979188;21594992;2...  \n",
+       "33             103       12  10756346;11175294;12203992;20979188;21594992;2...  \n",
        "291            105       11  10756346;11175294;12203992;20979188;21594992;2...  \n",
        "31              81       12  10756346;11175294;12203992;20979188;21594992;2...  "
       ]
      },
-     "execution_count": 5,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1044,7 +1044,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 14,
    "id": "af166de8",
    "metadata": {},
    "outputs": [],
@@ -1055,7 +1055,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 15,
    "id": "ce341f8b",
    "metadata": {},
    "outputs": [
@@ -1063,7 +1063,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Calculating pairwise synergy: 100%|██████████| 606/606 [01:06<00:00,  9.11it/s]\n"
+      "Calculating pairwise synergy: 100%|██████████| 606/606 [01:13<00:00,  8.25it/s]\n"
      ]
     },
     {
@@ -1266,7 +1266,7 @@
        "163        4                10756346;11175294;12203992;21683322  "
       ]
      },
-     "execution_count": 8,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1276,16 +1276,6 @@
     "    condition=condition_disease\n",
     ")\n",
     "results_disease.results_table.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aa260735",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "results_disease.save_synergy_heatmap()"
    ]
   },
   {
@@ -1316,7 +1306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "b93c47b3",
    "metadata": {},
    "outputs": [],
@@ -1327,7 +1317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "301d1b29",
    "metadata": {
     "nbsphinx": {
@@ -1347,7 +1337,7 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1358,7 +1348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "700efb0b",
    "metadata": {},
    "outputs": [],
@@ -1369,7 +1359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "8ed85fd4",
    "metadata": {},
    "outputs": [
@@ -1382,7 +1372,7 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1414,35 +1404,6 @@
     "Together, these steps provide a workflow for uncovering both global and condition-dependent relationships between phenotypic features.\n",
     "\n",
     "For additional usage patterns and parameter options, see the **Usage** section."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "654d74c0",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "0:88: execution error: File some object wasn’t found. (-43)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import webbrowser\n",
-    "webbrowser.open(\"file:///D:/storage/Master_Thesis/ppkt2synergy/docs/build/html/index.html\")"
    ]
   }
  ],

--- a/docs/source/usage/correlation.rst
+++ b/docs/source/usage/correlation.rst
@@ -61,7 +61,6 @@ Key parameters
 - `include_pmids``
   If ``True``, tracks and aggregates underlying PubMed IDs (PMIDs) contributing to the phenotypic overlaps for downstream publication verification.
 
-``n_jobs``
 
 .. warning::
 

--- a/src/ppkt2synergy/analysis/hpo_correlation_analyzer.py
+++ b/src/ppkt2synergy/analysis/hpo_correlation_analyzer.py
@@ -59,7 +59,7 @@ class CorrelationResult:
             Maximum adjusted p-value to retain.
 
         output_file : str, default="correlation_results.csv"
-            Output file path. Supported formats are ``.csv`` and ``.xlsx``.
+            Output file path. Supported formats are ``.csv``.
 
         Raises
         ------
@@ -80,14 +80,7 @@ class CorrelationResult:
                 raise ValueError("adj_pval_threshold must be between 0.0 and 1.0")
             df = df[df["adj_p_value"] < adj_pval_threshold]
 
-        ext = path.splitext(output_file)[1].lower()
-        if ext not in [".csv", ".xlsx"]:
-            raise ValueError(f"Unsupported file format: {ext}. Use '.csv' or '.xlsx'.")
-
-        if ext == ".csv":
-            df.to_csv(output_file, index=False)
-        else:
-            df.to_excel(output_file, index=False)    
+        df.to_csv(output_file, index=False)  
   
     def filter_weak_correlations(
         self, 
@@ -302,7 +295,7 @@ class CorrelationResult:
             z=nan_bg.values,
             x=coef_matrix.columns,
             y=coef_matrix.index,
-            colorscale=[[0, "#dbe7f3"], [1, "#dbe7f3"]],
+            colorscale=[[0, "#eef4fb"], [1, "#eef4fb"]],
             showscale=False,
             hoverinfo="skip",
             xgap=1,
@@ -312,7 +305,11 @@ class CorrelationResult:
                 z=display_matrix.values,
                 x=coef_matrix.columns,
                 y=coef_matrix.index,
-                colorscale="Tealgrn",
+                colorscale=[ 
+                [0.00, "#203864"],   # navy
+                [0.50, "#F7F4ED"],   # ivory
+                [1.00, "#7A1F3D"]    # wine
+                ],
                 zmin=-1,
                 zmax=1,
                 zmid=0,
@@ -567,7 +564,6 @@ class HPOCorrelationAnalyzer:
         ontology_values = self.relationship_mask[rows, cols]
         ontology_candidate = ~np.isnan(ontology_values)
 
-        n_pairs_before_filtering = len(rows)
         n_pairs_after_ontology = np.sum(ontology_candidate)
 
         candidate_idx = np.where(ontology_candidate & (counts >= self.min_individuals_for_correlation_test))[0]
@@ -580,7 +576,6 @@ class HPOCorrelationAnalyzer:
                 "[Correlation Analysis Blocked]: No HPO term pairs passed the candidate pre-filtering selection.\n"
                 "--------------------------------------------------------------------------------------------------\n"
                 "DIAGNOSIS SUMMARY:\n"
-                f"  - Total upper-triangle HPO pairs evaluated: {n_pairs_before_filtering}\n"
                 f"  - Pairs remaining after HPO Hierarchy Masking (excluding ancestors/descendants): {n_pairs_after_ontology}\n"
                 f"  - Pairs dropped due to low sample size (min_individuals_for_correlation_test={self.min_individuals_for_correlation_test}): {n_pairs_after_ontology}\n"
                 "SUGGESTION:\n"
@@ -651,7 +646,7 @@ class HPOCorrelationAnalyzer:
             _, pvals_corrected, _, _ = multipletests(pvals, method="fdr_bh")
             loc = int(self.correlation_results.columns.get_loc("p_value"))
             self.correlation_results.insert(loc + 1, "adj_p_value", pvals_corrected)
-            self.correlation_results.sort_values(by="p_value", ascending=True, inplace=True)
+            self.correlation_results.sort_values(by="adj_p_value", ascending=True, inplace=True)
         else:
             self.correlation_results["adj_p_value"] = pd.Series(dtype=float)
 

--- a/src/ppkt2synergy/analysis/synergy_analyzer.py
+++ b/src/ppkt2synergy/analysis/synergy_analyzer.py
@@ -60,7 +60,7 @@ class SynergyResult:
             Maximum adjusted p-value to retain.
 
         output_file : str, default="synergy_results.csv"
-            Output file path. Supported formats are ``.csv`` and ``.xlsx``.
+            Output file path. Supported formats are ``.csv``.
         """
         if self.synergy_results.empty:
             logger.warning("Synergy results table is empty. Saving empty file.")
@@ -75,15 +75,8 @@ class SynergyResult:
                 raise ValueError("adj_pval_threshold must be between 0.0 and 1.0.")
             df = df[df["adj_p_value"] < adj_pval_threshold]
 
-        ext = os.path.splitext(output_file)[1].lower()
-        if ext not in [".csv", ".xlsx"]:
-            raise ValueError(f"Unsupported file format: {ext}. Use '.csv' or '.xlsx'.")
-        
-        if ext == ".csv":
-            df.to_csv(output_file, index=False)
-        else:
-            df.to_excel(output_file, index=False)
-   
+     
+        df.to_csv(output_file, index=False)
     
     def filter_weak_synergy(
         self, 
@@ -295,18 +288,17 @@ class SynergyResult:
             z=nan_bg.values,
             x=synergy_matrix.columns,
             y=synergy_matrix.index,
-            colorscale=[[0, "#dbe7f3"], [1, "#dbe7f3"]],
+            colorscale=[[0, "#eef4fb"], [1, "#eef4fb"]],
             showscale=False,
             hoverinfo="skip",
             xgap=1,
             ygap=1,
         ))
-        colorscale = [
-            [0.0, "#eef6f5"],   
-            [0.25, "#c6e2df"],
-            [0.5, "#8fbfba"],
-            [0.75, "#4f8f8a"],
-            [1.0, "#1f4f4b"],   # deep muted teal
+        colorscale = [  
+            [0.00, "#f3e5f5"],
+            [0.35, "#ce93d8"],
+            [0.70, "#8e24aa"],
+            [1.00, "#4a148c"],  
         ]
         fig.add_trace(go.Heatmap(
                 z=display_matrix.values,
@@ -649,7 +641,6 @@ class SynergyAnalyzer:
         ontology_values = self.relationship_mask[rows, cols]
         ontology_candidate = ~np.isnan(ontology_values)
 
-        n_pairs_before_filtering = len(rows)
         n_pairs_after_ontology = np.sum(ontology_candidate)
 
         candidate_idx = np.where(ontology_candidate & (counts >= self.min_individuals_for_synergy_calculation))[0]
@@ -661,7 +652,6 @@ class SynergyAnalyzer:
                 "[Synergy Analysis Blocked]: No HPO pairs passed the candidate joint pre-filtering selection.\n"
                 "--------------------------------------------------------------------------------------------------\n"
                 "DIAGNOSIS SUMMARY:\n"
-                f"  - Total upper-triangle HPO pairs evaluated: {n_pairs_before_filtering}\n"
                 f"  - Pairs remaining after HPO Hierarchy Masking (excluding ancestors/descendants): {n_pairs_after_ontology}\n"
                 f"  - Pairs dropped due to low joint sample size (min_individuals_for_synergy_calculation={self.min_individuals_for_synergy_calculation}): {n_pairs_after_ontology - len(pairs)}\n"
                 "SUGGESTION :\n"
@@ -748,7 +738,7 @@ class SynergyAnalyzer:
                 "adj_p_value",
                 pvals_corrected
             )
-            self.synergy_results.sort_values(by="p_value", ascending=True, inplace=True)
+            self.synergy_results.sort_values(by="adj_p_value", ascending=True, inplace=True)
         else:
             self.synergy_results["adj_p_value"] = pd.Series(dtype=float)
         

--- a/tests/analysis/test_hpo_correlation_analyzer.py
+++ b/tests/analysis/test_hpo_correlation_analyzer.py
@@ -1,16 +1,14 @@
 import pandas as pd
 import pytest
-import plotly.graph_objects as go
 
 from ppkt2synergy.analysis.hpo_correlation_analyzer import (
     HPOCorrelationAnalyzer,
 )
-from ppkt2synergy.analysis.correlation_type import CorrelationType
 from ppkt2synergy.core import (
     PhenotypeDataset,
 )
 
-from ppkt2synergy.core.features import HpoFeatureData
+from ppkt2synergy.core.features_data import HpoFeatureData
 
 
 @pytest.fixture
@@ -83,23 +81,22 @@ def test_compute_correlation_matrix(large_dataset):
     )
 
     results = analyzer.compute_correlation_matrix(
-        correlation_type=CorrelationType.SPEARMAN,
         n_jobs=1,
         include_pmids=False,
     )
 
-    assert isinstance(results, pd.DataFrame)
+    assert isinstance(results.results_table, pd.DataFrame)
 
-    if not results.empty:
+    if not results.results_table.empty:
         expected = {
             "HPO_A",
             "HPO_B",
             "correlation",
             "p_value",
-            "p_value_corrected",
+            "adj_p_value",
         }
 
-        assert expected.issubset(results.columns)
+        assert expected.issubset(results.results_table.columns)
 
 
 def test_compute_correlation_matrix_happy_path(
@@ -111,12 +108,11 @@ def test_compute_correlation_matrix_happy_path(
     )
 
     results = analyzer.compute_correlation_matrix(
-        correlation_type=CorrelationType.SPEARMAN,
         n_jobs=1,
         include_pmids=False,
     )
 
-    assert not results.empty
+    assert not results.results_table.empty
 
 
 def test_filter_weak_correlations(
@@ -127,13 +123,12 @@ def test_filter_weak_correlations(
         min_individuals_for_correlation_test=10,
     )
 
-    analyzer.compute_correlation_matrix(
-        correlation_type=CorrelationType.SPEARMAN,
+    results = analyzer.compute_correlation_matrix(
         n_jobs=1,
         include_pmids=False,
     )
 
-    result = analyzer.filter_weak_correlations(
+    result = results.filter_weak_correlations(
         corr_threshold=0.0,
         adj_pval_threshold=1.0,
     )
@@ -144,25 +139,3 @@ def test_filter_weak_correlations(
 
     assert isinstance(coef, pd.DataFrame)
     assert isinstance(pval, pd.DataFrame)
-
-
-def test_plot_heatmap(
-    strongly_correlated_dataset,
-):
-    analyzer = HPOCorrelationAnalyzer(
-        strongly_correlated_dataset,
-        min_individuals_for_correlation_test=10,
-    )
-
-    analyzer.compute_correlation_matrix(
-        correlation_type=CorrelationType.SPEARMAN,
-        n_jobs=1,
-        include_pmids=False,
-    )
-
-    fig = analyzer.plot_correlation_heatmap_with_significance(
-        corr_threshold=0.0,
-        adj_pval_threshold=1.0,
-    )
-
-    assert isinstance(fig, go.Figure)

--- a/tests/analysis/test_synergy_analyzer.py
+++ b/tests/analysis/test_synergy_analyzer.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 from ppkt2synergy import SynergyAnalyzer
 from ppkt2synergy.core import PhenotypeDataset
 
-from ppkt2synergy.core.features import HpoFeatureData
+from ppkt2synergy.core.features_data import HpoFeatureData
 
 
 def _make_phenopackets(ids: list[str]) -> list:
@@ -56,29 +56,29 @@ def condition(dataset):
     return dataset.get_condition(alternating, name="test_condition")
 
 def test_init(dataset):
-    analyzer = SynergyAnalyzer(dataset, n_permutations=10)
+    analyzer = SynergyAnalyzer(dataset)
 
     assert analyzer.n_features == 4
     assert analyzer.X.shape[0] == 40
 
 
 def test_compute_synergy(dataset, condition):
-    analyzer = SynergyAnalyzer(dataset, n_permutations=10)
+    analyzer = SynergyAnalyzer(dataset)
 
     res = analyzer.compute_synergy_matrix(
         condition=condition,
         n_jobs=1,
     )
 
-    assert isinstance(res, pd.DataFrame)
+    assert isinstance(res.results_table, pd.DataFrame)
 
 
 def test_filter_synergy(dataset, condition):
-    analyzer = SynergyAnalyzer(dataset, n_permutations=10)
+    analyzer = SynergyAnalyzer(dataset)
 
-    analyzer.compute_synergy_matrix(condition=condition, n_jobs=1)
+    results = analyzer.compute_synergy_matrix(condition=condition, n_jobs=1)
 
-    out = analyzer.filter_weak_synergy(
+    out = results.filter_weak_synergy(
         synergy_threshold=0.0,
         adj_pval_threshold=1.0,
     )


### PR DESCRIPTION
@pnrobinson @aslgraefe 
Hi all, I’ve updated the package in this new version: the correlation module no longer computes Spearman and Kendall coefficients (only the remaining correlation measure is kept), and the synergy analysis now uses an adaptive permutation strategy for significance estimation. I also slightly refactored the API: compute_correlation_matrix() now returns a results object, so you access outputs via results.results_table and visualization via results.plot_correlation_heatmap_with_significance(title_name="...") instead of calling methods directly on the analyzer. The tutorial has been updated accordingly to reflect these changes.

